### PR TITLE
Web -> Chat View: Clear body on enter, track typing, limit length, etc

### DIFF
--- a/lib/elixirconf_chat_web/live/chat_live.ex
+++ b/lib/elixirconf_chat_web/live/chat_live.ex
@@ -148,7 +148,7 @@ defmodule ElixirconfChatWeb.ChatLive do
       Chat.leave_room(room_id, self())
     end
 
-    {:noreply, assign(socket, messages: [], room: nil, room_id: nil, room_page: false)}
+    {:noreply, assign(socket, body: "", messages: [], room: nil, room_id: nil, room_page: false)}
   end
 
   # Arbitrarily limit body size since we're keeping it in-memory, and because,
@@ -826,7 +826,7 @@ defmodule ElixirconfChatWeb.ChatLive do
           |> Enum.sort_by(& &1.posted_at, NaiveDateTime)
 
         {:noreply,
-         assign(socket, loading_room: false, room_page: true, messages: messages, room: room, room_id: room.id)}
+         assign(socket, body: "", loading_room: false, room_page: true, messages: messages, room: room, room_id: room.id)}
 
       _ ->
         # TODO: Handle error


### PR DESCRIPTION
Just some ideas.

(closes: #31)

1. With this the text clears as long as you don't press "Enter" before the initial debounce.
2. It tracks the body while typing.
3. Limits the length, who knows what people will do without limits...

Another option for clearing would be to use javascript and then it wouldn't require tracking the `body`?

Thoughts?