### PR TITLE
Persist token in localStorage and redirect to chat if found on auth page

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -21,9 +21,18 @@ import "phoenix_html"
 import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
 import topbar from "../vendor/topbar"
+import { ValidateAuthToken } from "./hooks/ValidateAuthToken"
+
+const Hooks = {
+  ValidateAuthToken,
+};
+
+window.addEventListener(`phx:persist_token`, (e) => {
+  localStorage.setItem('auth_token', e.detail.token);
+});
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
-let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}})
+let liveSocket = new LiveSocket("/live", Socket, {hooks: Hooks, params: {_csrf_token: csrfToken}})
 
 // Show progress bar on live navigation and form submits
 topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})

--- a/assets/js/hooks/ValidateAuthToken.js
+++ b/assets/js/hooks/ValidateAuthToken.js
@@ -1,0 +1,7 @@
+export const ValidateAuthToken = {
+  mounted() {
+    if (token = localStorage.getItem('auth_token')) {
+      this.pushEvent("validate_token", { token: token });
+    }
+  }
+}

--- a/lib/elixirconf_chat_web/live/auth_live.ex
+++ b/lib/elixirconf_chat_web/live/auth_live.ex
@@ -38,7 +38,7 @@ defmodule ElixirconfChatWeb.AuthLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="min-h-screen p-4 bg-brand-purple flex items-center align-center font-system">
+    <div id="main"class="min-h-screen p-4 bg-brand-purple flex items-center align-center font-system" phx-hook="ValidateAuthToken">
       <div class="mx-auto w-full max-w-[288px] min-[448px]:max-w-[412px] min-[532px]:max-w-[500px] p-4 min-[448px]:p-12 min-[532px]:p-15 bg-white rounded-[32px]">
       <.logo logo_title={true} {assigns} />
       <%= if assigns[:user] do %>
@@ -93,10 +93,6 @@ defmodule ElixirconfChatWeb.AuthLive do
         {:noreply,
          assign(socket, error: "Your login code has expired. Please go back and try again.")}
     end
-  end
-
-  def handle_event("set_login_code_buffer", %{"login_code" => login_code}, socket) do
-    {:noreply, assign(socket, login_code_buffer: login_code)}
   end
 
   ###


### PR DESCRIPTION
Fixes #47.

Web client now keys off existing persist_token event used by SwiftUI client to store token in localStorage. If token is found when root page is loaded, token is validated and user redirected to chat if valid.