### PR TITLE
Web: -> Chat view: make clickable area of rooms larger with hover state

### DIFF
--- a/lib/elixirconf_chat_web/components/user_count.ex
+++ b/lib/elixirconf_chat_web/components/user_count.ex
@@ -19,9 +19,9 @@ defmodule ElixirconfChatWeb.UserCountComponent do
 
   def render(assigns) do
     ~H"""
-    <p class="leading-5 text-brand-gray-600 group-hover:text-brand-purple">
+    <span class="leading-5 text-brand-gray-600 group-hover:text-brand-gray-100">
       <%= assigns[:count] %>
-    </p>
+    </span>
     """
   end
 

--- a/lib/elixirconf_chat_web/live/chat_live.ex
+++ b/lib/elixirconf_chat_web/live/chat_live.ex
@@ -227,7 +227,7 @@ defmodule ElixirconfChatWeb.ChatLive do
       <div class="px-2 py-[5px] flex items-center justify-between gap-x-2 border border-brand-gray-200 rounded-lg">
         <label class="sr-only" for="chat-input">Enter Message</label>
         <input class="w-[calc(100%-1rem)] py-2 px-2 text-lg md:text-xl text-brand-gray-400 border-none transition duration-200 focus:rounded-sm focus:ring-2 focus:ring-brand-purple" type="text" name="body" class="ph-24" placeholder="Enter Message..." id="chat-input" required />
-        <!-- TODO: clear text input on pressing enter -->
+        <%!-- TODO: clear text input on pressing enter --%>
         <button type="submit" class="w-10 h-10 flex items-center justify-center bg-brand-purple rounded-xl border-2 border-transparent group transition duration-200 hover:bg-white hover:border-brand-purple outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-purple">
           <span class="sr-only">Submit</span>
           <svg class="fill-white group-hover:fill-brand-purple" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path d="M3 13.0001H9V11.0001H3V1.8457C3 1.56956 3.22386 1.3457 3.5 1.3457C3.58425 1.3457 3.66714 1.36699 3.74096 1.4076L22.2034 11.562C22.4454 11.695 22.5337 11.9991 22.4006 12.241C22.3549 12.3241 22.2865 12.3925 22.2034 12.4382L3.74096 22.5925C3.499 22.7256 3.19497 22.6374 3.06189 22.3954C3.02129 22.3216 3 22.2387 3 22.1544V13.0001Z"></path></svg>
@@ -608,8 +608,8 @@ defmodule ElixirconfChatWeb.ChatLive do
           <h3>
             <%= @timeslot.formatted_string %>
           </h3>
-          <!-- TODO: Doors open or not -->
-          <span>Doors Open</span>
+          <%!-- TODO: Doors open or not --%>
+          <span></span>
         </div>
         <%= for room <- @timeslot.rooms do %>
           <div class="p-1">

--- a/lib/elixirconf_chat_web/live/chat_live.ex
+++ b/lib/elixirconf_chat_web/live/chat_live.ex
@@ -455,15 +455,16 @@ defmodule ElixirconfChatWeb.ChatLive do
 
   def hallway_item(assigns) do
     ~H"""
-    <div class="mt-5 p-3 bg-brand-gray-50 rounded-2xl">
-      <div class="flex items-center gap-2">
-        <button class="w-full uppercase font-semibold text-sm text-brand-gray-700 tracking-[3px] text-center cursor-pointer hover:text-brand-purple hover:underline outline-none focus-visible:outline-2 focus-visible:outline-offset-[6px] focus-visible:outline-brand-purple focus-visible:rounded-lg" phx-click="join_room" phx-value-room-id={"#{@room.id}"}>
-          <!-- TODO: Number of users online in Hallway -->
-          <span class="inline-block mr-3 w-2.5 h-2.5 bg-[#049372] rounded-full"></span><%= @room.title %>
-        </button>
-        <svg class="w-4 h-4 fill-brand-gray-500 group-hover:fill-brand-purple" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16"><path d="M2 22C2 17.5817 5.58172 14 10 14C14.4183 14 18 17.5817 18 22H16C16 18.6863 13.3137 16 10 16C6.68629 16 4 18.6863 4 22H2ZM10 13C6.685 13 4 10.315 4 7C4 3.685 6.685 1 10 1C13.315 1 16 3.685 16 7C16 10.315 13.315 13 10 13ZM10 11C12.21 11 14 9.21 14 7C14 4.79 12.21 3 10 3C7.79 3 6 4.79 6 7C6 9.21 7.79 11 10 11ZM18.2837 14.7028C21.0644 15.9561 23 18.752 23 22H21C21 19.564 19.5483 17.4671 17.4628 16.5271L18.2837 14.7028ZM17.5962 3.41321C19.5944 4.23703 21 6.20361 21 8.5C21 11.3702 18.8042 13.7252 16 13.9776V11.9646C17.6967 11.7222 19 10.264 19 8.5C19 7.11935 18.2016 5.92603 17.041 5.35635L17.5962 3.41321Z"></path></svg>
-        <.live_component module={UserCountComponent} id={"user_count_active_room_#{@room.id}-b"} room_id={@room.id} />
-      </div>
+    <div class="mt-5 bg-brand-gray-50 rounded-2xl">
+      <a class="block p-3 rounded-2xl outline-none transition duration-200 focus-visible:outline-2 focus-visible:outline-offset-1 hover:bg-brand-purple focus-visible:outline-brand-purple group" href="#" phx-click="join_room" phx-value-room-id={"#{@room.id}"} aria-label={"#{@room.title}"}>
+        <div class="flex items-center gap-2">
+          <div class="w-full uppercase font-semibold text-sm text-brand-gray-700 tracking-[3px] text-center group-hover:text-white" >
+            <span class="inline-block mr-3 w-2.5 h-2.5 bg-[#049372] rounded-full"></span><%= @room.title %>
+          </div>
+          <svg class="w-4 h-4 fill-brand-gray-500 group-hover:fill-brand-gray-100" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16"><path d="M2 22C2 17.5817 5.58172 14 10 14C14.4183 14 18 17.5817 18 22H16C16 18.6863 13.3137 16 10 16C6.68629 16 4 18.6863 4 22H2ZM10 13C6.685 13 4 10.315 4 7C4 3.685 6.685 1 10 1C13.315 1 16 3.685 16 7C16 10.315 13.315 13 10 13ZM10 11C12.21 11 14 9.21 14 7C14 4.79 12.21 3 10 3C7.79 3 6 4.79 6 7C6 9.21 7.79 11 10 11ZM18.2837 14.7028C21.0644 15.9561 23 18.752 23 22H21C21 19.564 19.5483 17.4671 17.4628 16.5271L18.2837 14.7028ZM17.5962 3.41321C19.5944 4.23703 21 6.20361 21 8.5C21 11.3702 18.8042 13.7252 16 13.9776V11.9646C17.6967 11.7222 19 10.264 19 8.5C19 7.11935 18.2016 5.92603 17.041 5.35635L17.5962 3.41321Z"></path></svg>
+          <.live_component module={UserCountComponent} id={"user_count_active_room_#{@room.id}-b"} room_id={@room.id} />
+        </div>
+      </a>
     </div>
     """
   end
@@ -617,15 +618,15 @@ defmodule ElixirconfChatWeb.ChatLive do
                 Track <%= Map.get(@track_labels, room.track, "?") %>
               </span>
             <% end %>
-            <a class="block px-2 py-1.5 rounded-2xl outline-none transition duration-300 focus-visible:outline-2 focus-visible:outline-offset-1 hover:bg-brand-purple focus-visible:outline-brand-purple focus-visible:rounded-lg group" href="#" phx-click="join_room" phx-value-room-id={"#{room.id}"} aria-label={room.title}>
+            <a class="block px-2 py-1.5 rounded-2xl outline-none transition duration-200 focus-visible:outline-2 focus-visible:outline-offset-1 hover:bg-brand-purple focus-visible:outline-brand-purple focus-visible:rounded-lg group" href="#" phx-click="join_room" phx-value-room-id={"#{room.id}"} aria-label={room.title}>
               <span class="w-full text-left font-medium text-xl/6 text-brand-gray-800 break-words group-hover:text-white"><%= room.title %></span>
               <%= if room.presenters != [] do %>
                 <div class="mt-1 mb-4 flex items-center justify-between">
                   <p class="leading-5 text-brand-gray-600 group-hover:text-brand-gray-100">
                     <%= Enum.join(room.presenters, ", ") %>
                   </p>
-                  <div class="flex items-center gap-x-2 group-hover:text-white">
-                    <svg class="w-4 h-4 fill-brand-gray-500 group-hover:fill-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16"><path d="M2 22C2 17.5817 5.58172 14 10 14C14.4183 14 18 17.5817 18 22H16C16 18.6863 13.3137 16 10 16C6.68629 16 4 18.6863 4 22H2ZM10 13C6.685 13 4 10.315 4 7C4 3.685 6.685 1 10 1C13.315 1 16 3.685 16 7C16 10.315 13.315 13 10 13ZM10 11C12.21 11 14 9.21 14 7C14 4.79 12.21 3 10 3C7.79 3 6 4.79 6 7C6 9.21 7.79 11 10 11ZM18.2837 14.7028C21.0644 15.9561 23 18.752 23 22H21C21 19.564 19.5483 17.4671 17.4628 16.5271L18.2837 14.7028ZM17.5962 3.41321C19.5944 4.23703 21 6.20361 21 8.5C21 11.3702 18.8042 13.7252 16 13.9776V11.9646C17.6967 11.7222 19 10.264 19 8.5C19 7.11935 18.2016 5.92603 17.041 5.35635L17.5962 3.41321Z"></path></svg>
+                  <div class="flex items-center gap-x-2">
+                    <svg class="w-4 h-4 fill-brand-gray-500 group-hover:fill-brand-gray-100" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16"><path d="M2 22C2 17.5817 5.58172 14 10 14C14.4183 14 18 17.5817 18 22H16C16 18.6863 13.3137 16 10 16C6.68629 16 4 18.6863 4 22H2ZM10 13C6.685 13 4 10.315 4 7C4 3.685 6.685 1 10 1C13.315 1 16 3.685 16 7C16 10.315 13.315 13 10 13ZM10 11C12.21 11 14 9.21 14 7C14 4.79 12.21 3 10 3C7.79 3 6 4.79 6 7C6 9.21 7.79 11 10 11ZM18.2837 14.7028C21.0644 15.9561 23 18.752 23 22H21C21 19.564 19.5483 17.4671 17.4628 16.5271L18.2837 14.7028ZM17.5962 3.41321C19.5944 4.23703 21 6.20361 21 8.5C21 11.3702 18.8042 13.7252 16 13.9776V11.9646C17.6967 11.7222 19 10.264 19 8.5C19 7.11935 18.2016 5.92603 17.041 5.35635L17.5962 3.41321Z"></path></svg>
                     <.live_component module={UserCountComponent} id={"user_count_#{room.id}"} room_id={room.id} />
                   </div>
                 </div>

--- a/lib/elixirconf_chat_web/live/chat_live.ex
+++ b/lib/elixirconf_chat_web/live/chat_live.ex
@@ -225,7 +225,7 @@ defmodule ElixirconfChatWeb.ChatLive do
     ~H"""
     <form class="p-4 md:p-6" id="chat" phx-submit="post_message">
       <div class="px-2 py-[5px] flex items-center justify-between gap-x-2 border border-brand-gray-200 rounded-lg">
-        <label class="sr-only" for="chat-input"></label>
+        <label class="sr-only" for="chat-input">Enter Message</label>
         <input class="w-[calc(100%-1rem)] py-2 px-2 text-lg md:text-xl text-brand-gray-400 border-none transition duration-200 focus:rounded-sm focus:ring-2 focus:ring-brand-purple" type="text" name="body" class="ph-24" placeholder="Enter Message..." id="chat-input" required />
         <!-- TODO: clear text input on pressing enter -->
         <button type="submit" class="w-10 h-10 flex items-center justify-center bg-brand-purple rounded-xl border-2 border-transparent group transition duration-200 hover:bg-white hover:border-brand-purple outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-purple">
@@ -500,7 +500,7 @@ defmodule ElixirconfChatWeb.ChatLive do
     ~H"""
     <%= for {day, timeslots} <- @sorted_days do %>
       <div>
-        <section class="mt-6" aria-labelledby="schedule-day">
+        <section class="mt-6" aria-labelledby={"schedule-day-#{day}"}>
           <h2 class="text-xl md:text-2xl text-brand-gray-800" id={"schedule-day-#{day}"}><%= day %></h2>
           <div class="mt-3 space-y-3">
             <%= for timeslot <- timeslots do %>

--- a/lib/elixirconf_chat_web/live/chat_live.ex
+++ b/lib/elixirconf_chat_web/live/chat_live.ex
@@ -601,9 +601,9 @@ defmodule ElixirconfChatWeb.ChatLive do
 
   def timeslot_item(assigns) do
     ~H"""
-    <div class="p-3 bg-brand-gray-50 rounded-2xl">
+    <div class="bg-brand-gray-50 rounded-2xl">
       <div>
-        <div class="mb-3 flex flex-wrap items-center justify-between uppercase font-semibold text-sm text-brand-gray-700 tracking-[3px]">
+        <div class="p-3 pb-2 flex flex-wrap items-center justify-between uppercase font-semibold text-sm text-brand-gray-700 tracking-[3px]">
           <h3>
             <%= @timeslot.formatted_string %>
           </h3>
@@ -611,28 +611,26 @@ defmodule ElixirconfChatWeb.ChatLive do
           <span>Doors Open</span>
         </div>
         <%= for room <- @timeslot.rooms do %>
-          <div>
+          <div class="p-1">
             <%= if room.track > 0 do %>
-              <span class="inline-block mb-2 px-3 py-1.5 rounded-lg border border-brand-gray-300 font-semibold text-brand-gray-500 text-xs uppercase tracking-[3px]">
+              <span class="inline-block mx-2 mb-0.5 px-2 py-1.5 rounded-lg border border-brand-gray-300 font-semibold text-brand-gray-500 text-xs uppercase tracking-[3px]">
                 Track <%= Map.get(@track_labels, room.track, "?") %>
               </span>
             <% end %>
-            <div>
-              <div>
-                <button class="w-full text-left font-medium text-xl/6 text-brand-gray-800 break-words cursor-pointer hover:text-brand-purple hover:underline outline-none focus-visible:outline-2 focus-visible:outline-offset-[6px] focus-visible:outline-brand-purple focus-visible:rounded-lg" phx-click="join_room" phx-value-room-id={"#{room.id}"}><%= room.title %></button>
-                <%= if room.presenters != [] do %>
-                  <div class="mt-1 mb-4 flex items-center justify-between">
-                    <p class="leading-5 text-brand-gray-600 group-hover:text-brand-purple">
-                      <%= Enum.join(room.presenters, ", ") %>
-                    </p>
-                    <div class="flex items-center gap-x-2">
-                      <svg class="w-4 h-4 fill-brand-gray-500 group-hover:fill-brand-purple" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16"><path d="M2 22C2 17.5817 5.58172 14 10 14C14.4183 14 18 17.5817 18 22H16C16 18.6863 13.3137 16 10 16C6.68629 16 4 18.6863 4 22H2ZM10 13C6.685 13 4 10.315 4 7C4 3.685 6.685 1 10 1C13.315 1 16 3.685 16 7C16 10.315 13.315 13 10 13ZM10 11C12.21 11 14 9.21 14 7C14 4.79 12.21 3 10 3C7.79 3 6 4.79 6 7C6 9.21 7.79 11 10 11ZM18.2837 14.7028C21.0644 15.9561 23 18.752 23 22H21C21 19.564 19.5483 17.4671 17.4628 16.5271L18.2837 14.7028ZM17.5962 3.41321C19.5944 4.23703 21 6.20361 21 8.5C21 11.3702 18.8042 13.7252 16 13.9776V11.9646C17.6967 11.7222 19 10.264 19 8.5C19 7.11935 18.2016 5.92603 17.041 5.35635L17.5962 3.41321Z"></path></svg>
-                      <.live_component module={UserCountComponent} id={"user_count_#{room.id}"} room_id={room.id} />
-                    </div>
+            <a class="block px-2 py-1.5 rounded-2xl outline-none transition duration-300 focus-visible:outline-2 focus-visible:outline-offset-1 hover:bg-brand-purple focus-visible:outline-brand-purple focus-visible:rounded-lg group" href="#" phx-click="join_room" phx-value-room-id={"#{room.id}"} aria-label={room.title}>
+              <span class="w-full text-left font-medium text-xl/6 text-brand-gray-800 break-words group-hover:text-white"><%= room.title %></span>
+              <%= if room.presenters != [] do %>
+                <div class="mt-1 mb-4 flex items-center justify-between">
+                  <p class="leading-5 text-brand-gray-600 group-hover:text-brand-gray-100">
+                    <%= Enum.join(room.presenters, ", ") %>
+                  </p>
+                  <div class="flex items-center gap-x-2 group-hover:text-white">
+                    <svg class="w-4 h-4 fill-brand-gray-500 group-hover:fill-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16"><path d="M2 22C2 17.5817 5.58172 14 10 14C14.4183 14 18 17.5817 18 22H16C16 18.6863 13.3137 16 10 16C6.68629 16 4 18.6863 4 22H2ZM10 13C6.685 13 4 10.315 4 7C4 3.685 6.685 1 10 1C13.315 1 16 3.685 16 7C16 10.315 13.315 13 10 13ZM10 11C12.21 11 14 9.21 14 7C14 4.79 12.21 3 10 3C7.79 3 6 4.79 6 7C6 9.21 7.79 11 10 11ZM18.2837 14.7028C21.0644 15.9561 23 18.752 23 22H21C21 19.564 19.5483 17.4671 17.4628 16.5271L18.2837 14.7028ZM17.5962 3.41321C19.5944 4.23703 21 6.20361 21 8.5C21 11.3702 18.8042 13.7252 16 13.9776V11.9646C17.6967 11.7222 19 10.264 19 8.5C19 7.11935 18.2016 5.92603 17.041 5.35635L17.5962 3.41321Z"></path></svg>
+                    <.live_component module={UserCountComponent} id={"user_count_#{room.id}"} room_id={room.id} />
                   </div>
-                <% end %>
-              </div>
-            </div>
+                </div>
+              <% end %>
+            </a>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
## In this PR

- Changed `<button>` elements containing `phx-click="join_room"`  to `<a>` tags instead so that the clickable area can be larger. `<a>` tags must have the `href` attribute in order to be treated as links by the browser (tab index, focusable, focus + enter).
- Adjusted padding for hover and focus states

## Screenshots

Hover state:
![Screenshot 2023-09-01 at 5 16 12 PM](https://github.com/liveview-native/elixirconf_chat/assets/39042045/5a12bd63-8287-4246-88af-ce62082c24da)

Focus state:
![Screenshot 2023-09-01 at 5 16 04 PM](https://github.com/liveview-native/elixirconf_chat/assets/39042045/f5762787-8528-4a59-a2bc-60a709b4ed67)

