### PR TITLE
Web: -> Chat view: make clickable area of rooms larger with hover state

### DIFF
--- a/lib/elixirconf_chat_web/components/active_user.ex
+++ b/lib/elixirconf_chat_web/components/active_user.ex
@@ -62,7 +62,7 @@ defmodule ElixirconfChatWeb.ActiveUserComponent do
     ~H"""
     <div class="flex items-center gap-x-2">
       <svg
-        class="w-4 h-4 fill-brand-gray-500 group-hover:fill-brand-purple"
+        class="w-4 h-4 fill-brand-gray-500 group-hover:fill-brand-gray-100"
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"
         width="16"
@@ -71,7 +71,7 @@ defmodule ElixirconfChatWeb.ActiveUserComponent do
         <path d="M2 22C2 17.5817 5.58172 14 10 14C14.4183 14 18 17.5817 18 22H16C16 18.6863 13.3137 16 10 16C6.68629 16 4 18.6863 4 22H2ZM10 13C6.685 13 4 10.315 4 7C4 3.685 6.685 1 10 1C13.315 1 16 3.685 16 7C16 10.315 13.315 13 10 13ZM10 11C12.21 11 14 9.21 14 7C14 4.79 12.21 3 10 3C7.79 3 6 4.79 6 7C6 9.21 7.79 11 10 11ZM18.2837 14.7028C21.0644 15.9561 23 18.752 23 22H21C21 19.564 19.5483 17.4671 17.4628 16.5271L18.2837 14.7028ZM17.5962 3.41321C19.5944 4.23703 21 6.20361 21 8.5C21 11.3702 18.8042 13.7252 16 13.9776V11.9646C17.6967 11.7222 19 10.264 19 8.5C19 7.11935 18.2016 5.92603 17.041 5.35635L17.5962 3.41321Z">
         </path>
       </svg>
-      <span class="leading-5 text-brand-gray-600 group-hover:text-brand-purple">
+      <span class="leading-5 text-brand-gray-600 group-hover:text-brand-gray-100">
         <%= assigns[:count] %>
       </span>
     </div>

--- a/lib/elixirconf_chat_web/live/chat_live.ex
+++ b/lib/elixirconf_chat_web/live/chat_live.ex
@@ -640,7 +640,7 @@ defmodule ElixirconfChatWeb.ChatLive do
     ~H"""
     <%= for {day, timeslots} <- @sorted_days do %>
       <div>
-        <section class="mt-6" aria-labelledby="schedule-day">
+        <section class="mt-6" aria-labelledby={"schedule-day-#{day}"}>
           <h2 class="text-xl md:text-2xl text-brand-gray-800" id={"schedule-day-#{day}"}>
             <%= day %>
           </h2>

--- a/lib/elixirconf_chat_web/live/chat_live.ex
+++ b/lib/elixirconf_chat_web/live/chat_live.ex
@@ -590,23 +590,21 @@ defmodule ElixirconfChatWeb.ChatLive do
 
   def hallway_item(assigns) do
     ~H"""
-    <div class="mt-5 p-3 bg-brand-gray-50 rounded-2xl">
-      <div class="flex items-center gap-2">
-        <button
-          class="w-full uppercase font-semibold text-sm text-brand-gray-700 tracking-[3px] text-center cursor-pointer hover:text-brand-purple hover:underline outline-none focus-visible:outline-2 focus-visible:outline-offset-[6px] focus-visible:outline-brand-purple focus-visible:rounded-lg"
-          phx-click="join_room"
-          phx-value-room-id={"#{@room.id}"}
-        >
-          <span class="inline-block mr-3 w-2.5 h-2.5 bg-[#049372] rounded-full"></span><%= @room.title %>
-        </button>
-        <.live_component
-          module={ActiveUserComponent}
-          id={"user_count_active_room_#{@room.id}-b"}
-          room_id={@room.id}
-          show_display_users_modal={false}
-          sidebar={true}
-        />
-      </div>
+    <div class="mt-5 bg-brand-gray-50 rounded-2xl">
+      <a class="block p-3 rounded-2xl outline-none transition duration-200 focus-visible:outline-2 focus-visible:outline-offset-1 hover:bg-brand-purple focus-visible:outline-brand-purple group" href="#" phx-click="join_room" phx-value-room-id={"#{@room.id}"} aria-label={"#{@room.title}"}>
+        <div class="flex items-center gap-2">
+          <div class="w-full uppercase font-semibold text-sm text-brand-gray-700 tracking-[3px] text-center group-hover:text-white" >
+            <span class="inline-block mr-3 w-2.5 h-2.5 bg-[#049372] rounded-full"></span><%= @room.title %>
+          </div>
+          <.live_component
+            module={ActiveUserComponent}
+            id={"user_count_active_room_#{@room.id}-b"}
+            room_id={@room.id}
+            show_display_users_modal={false}
+            sidebar={true}
+          />
+        </div>
+      </a>
     </div>
     """
   end

--- a/lib/elixirconf_chat_web/live/chat_live.ex
+++ b/lib/elixirconf_chat_web/live/chat_live.ex
@@ -748,9 +748,9 @@ defmodule ElixirconfChatWeb.ChatLive do
 
   def timeslot_item(assigns) do
     ~H"""
-    <div class="p-3 bg-brand-gray-50 rounded-2xl">
+    <div class="bg-brand-gray-50 rounded-2xl">
       <div>
-        <div class="mb-3 flex flex-wrap items-center justify-between uppercase font-semibold text-sm text-brand-gray-700 tracking-[3px]">
+        <div class="p-3 pb-2 flex flex-wrap items-center justify-between uppercase font-semibold text-sm text-brand-gray-700 tracking-[3px]">
           <h3>
             <%= @timeslot.formatted_string %>
           </h3>
@@ -758,37 +758,29 @@ defmodule ElixirconfChatWeb.ChatLive do
           <span></span>
         </div>
         <%= for room <- @timeslot.rooms do %>
-          <div>
+          <div class="p-1">
             <%= if room.track > 0 do %>
-              <span class="inline-block mb-2 px-3 py-1.5 rounded-lg border border-brand-gray-300 font-semibold text-brand-gray-500 text-xs uppercase tracking-[3px]">
+              <span class="inline-block mx-2 mb-0.5 px-2 py-1.5 rounded-lg border border-brand-gray-300 font-semibold text-brand-gray-500 text-xs uppercase tracking-[3px]">
                 Track <%= Map.get(@track_labels, room.track, "?") %>
               </span>
             <% end %>
-            <div>
-              <div>
-                <button
-                  class="w-full text-left font-medium text-xl/6 text-brand-gray-800 break-words cursor-pointer hover:text-brand-purple hover:underline outline-none focus-visible:outline-2 focus-visible:outline-offset-[6px] focus-visible:outline-brand-purple focus-visible:rounded-lg"
-                  phx-click="join_room"
-                  phx-value-room-id={"#{room.id}"}
-                >
-                  <%= room.title %>
-                </button>
-                <%= if room.presenters != [] do %>
-                  <div class="mt-1 mb-4 flex items-center justify-between">
-                    <p class="leading-5 text-brand-gray-600 group-hover:text-brand-purple">
-                      <%= Enum.join(room.presenters, ", ") %>
-                    </p>
-                    <.live_component
-                      module={ActiveUserComponent}
-                      id={"user_count_#{room.id}"}
-                      room_id={room.id}
-                      show_display_users_modal={false}
-                      sidebar={true}
-                    />
-                  </div>
-                <% end %>
-              </div>
-            </div>
+            <a class="block px-2 py-1.5 rounded-2xl outline-none transition duration-200 focus-visible:outline-2 focus-visible:outline-offset-1 hover:bg-brand-purple focus-visible:outline-brand-purple focus-visible:rounded-lg group" href="#" phx-click="join_room" phx-value-room-id={"#{room.id}"} aria-label={room.title}>
+              <span class="w-full text-left font-medium text-xl/6 text-brand-gray-800 break-words group-hover:text-white"><%= room.title %></span>
+              <%= if room.presenters != [] do %>
+                <div class="mt-1 mb-4 flex items-center justify-between">
+                  <p class="leading-5 text-brand-gray-600 group-hover:text-brand-gray-100">
+                    <%= Enum.join(room.presenters, ", ") %>
+                  </p>
+                  <.live_component
+                    module={ActiveUserComponent}
+                    id={"user_count_#{room.id}"}
+                    room_id={room.id}
+                    show_display_users_modal={false}
+                    sidebar={true}
+                  />
+                </div>
+              <% end %>
+            </a>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
## In this PR

- Changed `<button>` elements containing `phx-click="join_room"`  to `<a>` tags instead so that the clickable area can be larger. `<a>` tags must have the `href` attribute in order to be treated as links by the browser (tab index, focusable, focus + enter).
- Adjusted padding for hover and focus states

Web app: Fixes #39 

## Screenshots

Hover state:
![Screenshot 2023-09-01 at 5 16 12 PM](https://github.com/liveview-native/elixirconf_chat/assets/39042045/5a12bd63-8287-4246-88af-ce62082c24da)

Focus state:
![Screenshot 2023-09-01 at 5 16 04 PM](https://github.com/liveview-native/elixirconf_chat/assets/39042045/f5762787-8528-4a59-a2bc-60a709b4ed67)